### PR TITLE
Fix issue #10 and a bunch of other stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "simple_logger",
+ "socket2 0.5.10",
  "tokio",
  "uuid",
 ]
@@ -347,6 +348,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -411,7 +422,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -518,11 +529,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -536,20 +556,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -559,9 +601,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -571,9 +625,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -583,15 +649,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/mineginx/Cargo.toml
+++ b/mineginx/Cargo.toml
@@ -16,3 +16,4 @@ tokio = { version = "1.49.0", features = ["full"] }
 uuid = { version = "1.20.0", features = ["v4"] }
 log = { version = "0.4" }
 simple_logger = { version = "5.1.0" }
+socket2 = "0.5"

--- a/mineginx/src/main.rs
+++ b/mineginx/src/main.rs
@@ -168,8 +168,12 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>, resol
 
 async fn handle_address(listener: &TcpListener, config: Arc<MineginxConfig>, resolved: Arc<RwLock<HashMap<String, ResolvedUpstream>>>) {
     loop {
+        debug!("accept loop waiting for connection");
         let (socket, _address) = match listener.accept().await {
-            Ok(x) => x,
+            Ok(x) => {
+                debug!("accept() returned a connection");
+                x
+            },
             Err(e) => {
                 error!("failed to accept client: {e}");
                 continue;
@@ -180,6 +184,7 @@ async fn handle_address(listener: &TcpListener, config: Arc<MineginxConfig>, res
         tokio::spawn(async move {
             handle_client(socket, conf, res).await;
         });
+        debug!("spawned handler, looping back to accept");
     }
 }
 

--- a/mineginx/src/main.rs
+++ b/mineginx/src/main.rs
@@ -1,5 +1,5 @@
 use std::{
-    borrow::BorrowMut, collections::HashMap, env, fs::{self}, io::ErrorKind, path::Path, process::ExitCode, sync::Arc, time::Duration
+    borrow::BorrowMut, collections::HashMap, env, fs::{self}, io::ErrorKind, net::{SocketAddr, ToSocketAddrs}, path::Path, process::ExitCode, sync::Arc, time::Duration
 };
 use config::{MinecraftServerDescription, MineginxConfig};
 use log::{error, info, warn};
@@ -11,11 +11,26 @@ use stream::forward_half;
 mod stream;
 mod config;
 
-fn find_upstream(domain: &String, config: Arc<MineginxConfig>) -> Option<MinecraftServerDescription> {
+/// Holds upstream info with a pre-resolved socket address so that
+/// per-connection connects skip DNS entirely. On musl + scratch containers,
+/// getaddrinfo() is synchronous and blocks the tokio blocking threadpool,
+/// which can stall the accept loop and block all new connections/pings.
+#[derive(Clone)]
+struct ResolvedUpstream {
+    proxy_pass: String,
+    addr: SocketAddr,
+    buffer_size: Option<u32>,
+}
+
+fn find_upstream(domain: &str, config: &MineginxConfig, resolved: &HashMap<String, ResolvedUpstream>) -> Option<ResolvedUpstream> {
+    // Strip trailing dot from client domain — Minecraft clients send FQDN
+    // (e.g. "mc.kaydax.xyz.") but configs typically use bare names
+    let domain = domain.trim_end_matches('.');
     for x in &config.servers {
         for server_name in &x.server_names {
-            if server_name == domain {
-                return Some(x.clone());
+            let cfg_name = server_name.trim_end_matches('.');
+            if cfg_name.eq_ignore_ascii_case(domain) {
+                return resolved.get(&x.proxy_pass).cloned();
             }
         }
     }
@@ -31,7 +46,7 @@ async fn read_handshake_packet(client: &mut MinecraftStream<&mut TcpStream>) -> 
     Ok(handshake)
 }
 
-async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>) {
+async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>, resolved: Arc<HashMap<String, ResolvedUpstream>>) {
     if let Err(e) = client.set_nodelay(true) {
         error!("failed to set no_delay for client: {}", e);
         return;
@@ -56,7 +71,7 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>) {
     };
 
     let domain = truncate_to_zero(&handshake.domain).to_string();
-    let upstream_server = match find_upstream(&domain, config.clone()) {
+    let upstream = match find_upstream(&domain, &config, &resolved) {
         Some(x) => x,
         None => {
             warn!("there is no upstream for domain {:#?}", &domain);
@@ -64,16 +79,17 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>) {
         }
     };
 
-    info!("new connection (protocol_version: {}, domain: {}, upstream: {})", &handshake.protocol_version, &domain, upstream_server.proxy_pass);
+    info!("new connection (protocol_version: {}, domain: {}, upstream: {})", &handshake.protocol_version, &domain, upstream.proxy_pass);
 
-    let mut upstream = match TcpStream::connect(&upstream_server.proxy_pass).await {
+    // Connect using the pre-resolved SocketAddr — no DNS lookup at connection time
+    let mut upstream_conn = match TcpStream::connect(upstream.addr).await {
         Ok(x) => x,
         Err(e) => {
-            error!("failed to connect upstream: {}, {e}", &upstream_server.proxy_pass);
+            error!("failed to connect upstream: {}, {e}", &upstream.proxy_pass);
             return;
         }
     };
-    if let Err(e) = upstream.set_nodelay(true) {
+    if let Err(e) = upstream_conn.set_nodelay(true) {
         error!("failed to set no_delay for upstream: {}", e);
         return;
     }
@@ -81,12 +97,12 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>) {
         Some(v) => v,
         None => return
     };
-    match upstream.write_all(&packet[0..packet.len()]).await {
+    match upstream_conn.write_all(&packet[0..packet.len()]).await {
         Ok(_) => { },
         Err(_) => return
     };
     // flush unread buffer to the upstream
-    match upstream.write_all(&minecraft.take_buffer()).await {
+    match upstream_conn.write_all(&minecraft.take_buffer()).await {
         Ok(_) => {},
         Err(_) => {
             return;
@@ -94,8 +110,8 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>) {
     }
 
     let (client_reader, client_writer) = client.into_split();
-    let (upstream_reader, upstream_writer) = upstream.into_split();
-    let buf_size = upstream_server.buffer_size.map(|b| b as usize).unwrap_or(8192);
+    let (upstream_reader, upstream_writer) = upstream_conn.into_split();
+    let buf_size = upstream.buffer_size.map(|b| b as usize).unwrap_or(8192);
 
     // Each direction gets its own spawned task so the tokio scheduler
     // can freely interleave them with the accept loop and other connections.
@@ -106,10 +122,10 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>) {
     let s2c = forward_half(upstream_reader, client_writer, buf_size);
 
     let _ = tokio::join!(c2s, s2c);
-    info!("connection closed (domain: {}, upstream: {})", &domain, upstream_server.proxy_pass);
+    info!("connection closed (domain: {}, upstream: {})", &domain, upstream.proxy_pass);
 }
 
-async fn handle_address(listener: &TcpListener, config: Arc<MineginxConfig>) {
+async fn handle_address(listener: &TcpListener, config: Arc<MineginxConfig>, resolved: Arc<HashMap<String, ResolvedUpstream>>) {
     loop {
         let (socket, _address) = match listener.accept().await {
             Ok(x) => x,
@@ -119,8 +135,9 @@ async fn handle_address(listener: &TcpListener, config: Arc<MineginxConfig>) {
             }
         };
         let conf = config.clone();
+        let res = resolved.clone();
         tokio::spawn(async move {
-            handle_client(socket, conf).await;
+            handle_client(socket, conf, res).await;
         });
     }
 }
@@ -211,6 +228,38 @@ async fn main() -> ExitCode {
             return  ExitCode::from(2);
         }
     };
+
+    // Pre-resolve all upstream DNS at startup so per-connection connects
+    // use raw SocketAddr and never touch DNS. On musl (used in scratch
+    // containers), getaddrinfo() is synchronous and blocks tokio's
+    // blocking threadpool, which can stall the accept loop.
+    let mut resolved = HashMap::<String, ResolvedUpstream>::new();
+    for server in &config.servers {
+        if resolved.contains_key(&server.proxy_pass) {
+            continue;
+        }
+        let addr = match server.proxy_pass.to_socket_addrs() {
+            Ok(mut addrs) => match addrs.next() {
+                Some(a) => a,
+                None => {
+                    error!("failed to resolve upstream '{}': no addresses returned", &server.proxy_pass);
+                    return ExitCode::from(4);
+                }
+            },
+            Err(e) => {
+                error!("failed to resolve upstream '{}': {e}", &server.proxy_pass);
+                return ExitCode::from(4);
+            }
+        };
+        info!("resolved upstream {} -> {}", &server.proxy_pass, addr);
+        resolved.insert(server.proxy_pass.clone(), ResolvedUpstream {
+            proxy_pass: server.proxy_pass.clone(),
+            addr,
+            buffer_size: server.buffer_size,
+        });
+    }
+    let resolved = Arc::new(resolved);
+
     let mut listening = HashMap::<String, ListeningAddress>::new();
     for server in &config.servers {
         if listening.contains_key(&server.listen) {
@@ -225,8 +274,9 @@ async fn main() -> ExitCode {
             }
         };
         let conf = config.clone();
+        let res = resolved.clone();
         let task = tokio::spawn(async move {
-            handle_address(&listener, conf).await;
+            handle_address(&listener, conf, res).await;
         });
         listening.insert(server.listen.to_string(), ListeningAddress(task));
     }

--- a/mineginx/src/main.rs
+++ b/mineginx/src/main.rs
@@ -92,10 +92,14 @@ async fn handle_client(mut client: TcpStream, config: Arc<MineginxConfig>, resol
 
     // Look up the pre-resolved address, or try resolving on-the-fly
     // for upstreams that weren't available at startup
+    debug!("looking up upstream for {} from {:?}", &server_desc.proxy_pass, peer);
     let upstream = {
+        debug!("acquiring read lock from {:?}", peer);
         let cache = resolved.read().await;
+        debug!("got read lock from {:?}", peer);
         cache.get(&server_desc.proxy_pass).cloned()
     };
+    debug!("released read lock from {:?}, found: {}", peer, upstream.is_some());
     let upstream = match upstream {
         Some(u) => u,
         None => {

--- a/mineginx/src/stream.rs
+++ b/mineginx/src/stream.rs
@@ -5,11 +5,7 @@ use tokio::{
 };
 
 /// Forwards data from `reader` to `writer` until EOF or error,
-/// then shuts down the writer (sends TCP FIN to the remote end).
-///
-/// Each direction of a proxied connection gets its own spawned task
-/// so the tokio scheduler can interleave them with the accept loop
-/// and other connections freely.
+/// then shuts down the writer (sends TCP FIN).
 pub fn forward_half(
     mut reader: OwnedReadHalf,
     mut writer: OwnedWriteHalf,
@@ -27,9 +23,6 @@ pub fn forward_half(
                 }
             }
         }
-        // Shut down the write half so the remote end receives FIN.
-        // The other forwarding task (opposite direction) will then
-        // naturally read EOF and terminate on its own — no signaling needed.
         _ = writer.shutdown().await;
     })
 }

--- a/mineginx/src/stream.rs
+++ b/mineginx/src/stream.rs
@@ -1,44 +1,35 @@
 use tokio::{
     task::JoinHandle,
-    sync::oneshot::{
-        Sender, Receiver
-    },
-    net::tcp::{
-        OwnedReadHalf, OwnedWriteHalf
-    },
-    io::{AsyncReadExt, AsyncWriteExt}
+    net::tcp::{OwnedReadHalf, OwnedWriteHalf},
+    io::{AsyncReadExt, AsyncWriteExt},
 };
 
-pub fn forward_stream(
-    close: Sender<()>,
-    mut close_by_other: Receiver<()>,
+/// Forwards data from `reader` to `writer` until EOF or error,
+/// then shuts down the writer (sends TCP FIN to the remote end).
+///
+/// Each direction of a proxied connection gets its own spawned task
+/// so the tokio scheduler can interleave them with the accept loop
+/// and other connections freely.
+pub fn forward_half(
     mut reader: OwnedReadHalf,
     mut writer: OwnedWriteHalf,
-    buffer_size: usize) -> JoinHandle<()> {
+    buffer_size: usize,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut buf = vec![0; buffer_size];
         loop {
-            tokio::select! {
-                _ = &mut close_by_other => {
-                    break;
-                },
-                res = reader.read(&mut buf) => {
-                    match res {
-                        Ok(0) | Err(_) => break,
-                        Ok(size) => {
-                            if writer.write_all(&buf[..size]).await.is_err() {
-                                break;
-                            }
-                        }
+            match reader.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if writer.write_all(&buf[..n]).await.is_err() {
+                        break;
                     }
                 }
             }
         }
-        // Signal the other forwarding task to stop (dropping the sender
-        // causes the receiver to resolve, which triggers its close_by_other branch)
-        drop(close);
-        // Shut down write half so the remote end receives FIN immediately
-        // instead of waiting for its own keepalive/timeout to detect the dead connection
+        // Shut down the write half so the remote end receives FIN.
+        // The other forwarding task (opposite direction) will then
+        // naturally read EOF and terminate on its own — no signaling needed.
         _ = writer.shutdown().await;
     })
 }

--- a/mineginx/src/stream.rs
+++ b/mineginx/src/stream.rs
@@ -1,7 +1,7 @@
 use tokio::{
     task::JoinHandle,
     sync::oneshot::{
-        Sender, Receiver, error::TryRecvError
+        Sender, Receiver
     },
     net::tcp::{
         OwnedReadHalf, OwnedWriteHalf
@@ -11,50 +11,34 @@ use tokio::{
 
 pub fn forward_stream(
     close: Sender<()>,
-    close_by_other: Receiver<()>,
+    mut close_by_other: Receiver<()>,
     mut reader: OwnedReadHalf,
     mut writer: OwnedWriteHalf,
     buffer_size: usize) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut buf = vec![0; buffer_size];
-        let mut close = Some(close);
-        let mut close_by_other = Some(close_by_other);
-        let mut closed = false;
         loop {
-            if let Some(mut receiver) = close_by_other.take() {
-                match receiver.try_recv() {
-                    Err(e ) => closed |= e == TryRecvError::Closed,
-                    Ok(_) => closed = true
-                }
-            }
-            if closed {
-                return;
-            }
-            let res = reader.read(&mut buf).await;
-            match res {
-                Ok(size) => {
-                    if size == 0 {
-                        if let Some(sender) = close.take() {
-                            closed = true;
-                            _ = sender.send(());
-                        }
-                    }
-                    let writed = writer.write_all(&buf[..size]).await;
-                    match writed {
-                        Ok(_) => { },
-                        Err(_) => {
-                            if let Some(sender) = close.take() {
-                                _ = sender.send(())
+            tokio::select! {
+                _ = &mut close_by_other => {
+                    return;
+                },
+                res = reader.read(&mut buf) => {
+                    match res {
+                        Ok(0) => {
+                            _ = close.send(());
+                            return;
+                        },
+                        Ok(size) => {
+                            if writer.write_all(&buf[..size]).await.is_err() {
+                                _ = close.send(());
+                                return;
                             }
+                        },
+                        Err(_) => {
+                            _ = close.send(());
                             return;
                         }
                     }
-                },
-                Err(_) => {
-                    if let Some(sender) = close.take() {
-                        _ = sender.send(());
-                    }
-                    return;
                 }
             }
         }


### PR DESCRIPTION
Here is a bunch of changes that fix #10 and also fixes a random crash that happens. Also improve the code base to be way more robust.

I was sent down a rabbit hole because of the fact I forgot to up the file descriptor limit on my proxy server that sits between cloudflare and mineginx, thus causing connection limits

List of changes so far:
- Fixed buffer expansion panic (`todo!()` → actual implementation)
- Fixed off-by-one in buffer data length calculation
- Fixed packet data length check after reading packet ID
- Fixed string reader bounds check and UTF-8 panic
- Added panic logging for spawned tasks
- Replaced `.unwrap()` calls in main with error handling
- Fixed TCP connections not sending FIN on close
- Ensured forwarding tasks are awaited before cleanup
- Fixed domain matching to handle trailing dots and case differences
- Set global panic hook for crash diagnostics
- Used socket2 for TCP listener with 1024 backlog and SO_REUSEADDR